### PR TITLE
히트맵 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
-import MainLayout from './components/templates/MainLayout';
-import HomePage from './pages/HomePage';
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import MainLayout from "./components/templates/MainLayout";
+import HeatmapPage from "./pages/HeatmapPage";
+import HomePage from "./pages/HomePage";
 
 function App() {
   return (
@@ -8,8 +9,12 @@ function App() {
       <Routes>
         {/* MainLayout이 모든 페이지의 부모가 됩니다 */}
         <Route path="/" element={<MainLayout />}>
-          {/* 그 안에 HomePage가 자식으로 들어갑니다 (Outlet) */}
+          {/* 1. 홈 화면 (기본 경로) */}
           <Route index element={<HomePage />} />
+
+          {/* 2. 히트맵 화면 (추가된 부분) */}
+          {/* path="heatmap"은 "/heatmap" 경로로 접속했을 때를 의미합니다 */}
+          <Route path="heatmap" element={<HeatmapPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,25 +1,28 @@
-import type { ButtonHTMLAttributes } from 'react';
-import { cn } from '../../lib/utils';
+import type { ButtonHTMLAttributes } from "react";
+import { cn } from "../../lib/utils";
 
 // 버튼의 스타일 종류 정의
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'ghost' | 'outline';
+  variant?: "primary" | "ghost";
 }
 
-const Button = ({ className, variant = 'primary', children, ...props }: ButtonProps) => {
-  const baseStyles = "px-4 py-2 rounded-lg font-medium transition-colors duration-transitionDuration flex items-center justify-center gap-2 text-base";
-  
+const Button = ({
+  className,
+  variant = "primary",
+  children,
+  ...props
+}: ButtonProps) => {
+  const baseStyles =
+    "px-4 py-2 rounded-lg font-medium transition-colors duration-transitionDuration flex items-center justify-center gap-2 text-base";
+
   const variants = {
     primary: "bg-blue-600 text-slate-50 hover:bg-blue-700 shadow-sm", // 로그인 버튼용
-    ghost: "bg-transparent text-headerText hover:text-headerTextHover dark:hover:text-headerTextHover", // 메뉴용
-    outline: "border border-slate-300 text-headerText hover:text-headerTextHover" // 기타
+    ghost:
+      "bg-transparent text-headerText hover:text-headerTextHover dark:hover:text-headerTextHover", // 메뉴용
   };
 
   return (
-    <button 
-      className={cn(baseStyles, variants[variant], className)} 
-      {...props}
-    >
+    <button className={cn(baseStyles, variants[variant], className)} {...props}>
       {children}
     </button>
   );

--- a/src/components/atoms/FearGreedGauge.tsx
+++ b/src/components/atoms/FearGreedGauge.tsx
@@ -247,7 +247,7 @@ const FearGreedGauge = ({ score }: FearGreedGaugeProps) => {
         <path
           d={describeArc(cx, cy, radius * 0.3, 0, 180)}
           className="fill-bodyBg text-bodyText"
-          filter="url(#topShadow)"
+          filter={`url(#topShadow-${uniqueId})`}
         />
       </svg>
 

--- a/src/components/atoms/FearGreedGauge.tsx
+++ b/src/components/atoms/FearGreedGauge.tsx
@@ -211,7 +211,7 @@ const FearGreedGauge = ({ score }: FearGreedGaugeProps) => {
         {/* 6. 바늘 */}
         <g
           className="origin-bottom"
-          clipPath="url(#gaugeClip)"
+          clipPath={`url(#gaugeClip-${uniqueId})`}
           style={{
             transformBox: "fill-box",
             transformOrigin: "center bottom",

--- a/src/components/atoms/ScrollIndicator.tsx
+++ b/src/components/atoms/ScrollIndicator.tsx
@@ -53,9 +53,9 @@ const ScrollIndicator = ({
         pointer-events-auto cursor-pointer hover:opacity-80"
       >
         {direction === "down" ? (
-          <MdArrowDropDown className="w-10 h-10 text-bodyText -mb-1" />
+          <MdArrowDropDown className="w-10 h-10 text-bodyText" />
         ) : (
-          <MdArrowDropUp className="w-10 h-10 text-bodyText -mt-1" />
+          <MdArrowDropUp className="w-10 h-10 text-bodyText" />
         )}
       </div>
     </div>

--- a/src/components/atoms/ScrollIndicator.tsx
+++ b/src/components/atoms/ScrollIndicator.tsx
@@ -1,0 +1,65 @@
+import { MdArrowDropDown, MdArrowDropUp } from "react-icons/md";
+
+interface ScrollIndicatorProps {
+  direction?: "up" | "down"; // 방향 설정 (기본값: down)
+  className?: string; // 위치 커스텀을 위한 클래스 (예: top-20)
+}
+
+const ScrollIndicator = ({
+  direction = "down",
+  className,
+}: ScrollIndicatorProps) => {
+  // 클릭 핸들러 함수
+  const handleClick = () => {
+    const scrollContainer = document.querySelector(".snap-y");
+
+    // 스크롤할 대상 (컨테이너가 없으면 window)
+    const target = scrollContainer || window;
+    // 스크롤할 높이 (컨테이너 높이 또는 윈도우 높이)
+    const height = scrollContainer
+      ? scrollContainer.clientHeight
+      : window.innerHeight;
+
+    // 방향에 따른 스크롤 양 계산 (Down: +, Up: -)
+    const scrollAmount = direction === "down" ? height : -height;
+
+    target.scrollBy({
+      top: scrollAmount,
+      behavior: "smooth",
+    });
+  };
+
+  // 기본 위치 설정: className이 없으면 방향에 따라 자동 설정
+  // Up일 때는 헤더(h-16)를 고려하여 top-20 정도로 설정
+  const positionClass = className
+    ? className
+    : direction === "down"
+    ? "bottom-4"
+    : "top-24";
+
+  return (
+    <div
+      className={`absolute left-1/2 -translate-x-1/2 z-20 pointer-events-none select-none flex flex-col items-center gap-2 ${positionClass}`}
+    >
+      {/* 배경 블러 박스 (Glassmorphism) */}
+      <div
+        onClick={handleClick}
+        className="flex flex-col items-center justify-center px-1 py-1 rounded-full 
+        bg-glass
+        backdrop-blur-md
+        border border-glass-border
+        shadow-lg shadow-shadowColor
+        transition-colors duration-transitionDuration
+        pointer-events-auto cursor-pointer hover:opacity-80"
+      >
+        {direction === "down" ? (
+          <MdArrowDropDown className="w-10 h-10 text-bodyText -mb-1" />
+        ) : (
+          <MdArrowDropUp className="w-10 h-10 text-bodyText -mt-1" />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ScrollIndicator;

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -20,7 +20,7 @@ const Header = () => {
     // 헤더 전체 틀
     <header className="w-full h-16 border-b border-border bg-background sticky top-0 z-50 transition-colors duration-transitionDuration">
       {/* 내부 컨텐츠 (최대 너비 1440px로 제한 & 중앙 정렬) */}
-      <div className="max-w-[1440px] mx-auto px-10 h-full flex items-center justify-between">
+      <div className="max-w-[1440px] mx-2.5 px-10 h-full flex items-center justify-between">
         {/* [왼쪽] 로고 + 네비게이션 */}
         <div className="flex items-center gap-8">
           <Link to="/">

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -20,7 +20,7 @@ const Header = () => {
     // 헤더 전체 틀
     <header className="w-full h-16 border-b border-border bg-background sticky top-0 z-50 transition-colors duration-transitionDuration">
       {/* 내부 컨텐츠 (최대 너비 1440px로 제한 & 중앙 정렬) */}
-      <div className="max-w-[1440px] mx-2 px-10 h-full flex items-center justify-between">
+      <div className="max-w-[1440px] mx-auto px-10 h-full flex items-center justify-between">
         {/* [왼쪽] 로고 + 네비게이션 */}
         <div className="flex items-center gap-8">
           <Link to="/">

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -1,18 +1,26 @@
-import { MdAccountCircle, MdLanguage } from "react-icons/md";
-import { Link } from "react-router-dom";
+import { MdAccountCircle } from "react-icons/md";
+import { Link, NavLink } from "react-router-dom";
+import { cn } from "../../lib/utils";
 import Button from "../atoms/Button";
 import Logo from "../atoms/Logo";
 import SearchBar from "../molecules/SearchBar";
 import ThemeToggle from "../molecules/ThemeToggle";
 
 const Header = () => {
-  const menuItems = ["홈", "뉴스", "히트맵", "주식", "환율", "코인"];
+  const menuItems = [
+    { label: "홈", path: "/" },
+    { label: "뉴스", path: "/news" },
+    { label: "히트맵", path: "/heatmap" },
+    { label: "주식", path: "/stocks" },
+    { label: "환율", path: "/exchange" },
+    { label: "코인", path: "/crypto" },
+  ];
 
   return (
     // 헤더 전체 틀
     <header className="w-full h-16 border-b border-border bg-background sticky top-0 z-50 transition-colors duration-transitionDuration">
       {/* 내부 컨텐츠 (최대 너비 1440px로 제한 & 중앙 정렬) */}
-      <div className="max-w-[1440px] mx-auto px-10 h-full flex items-center justify-between">
+      <div className="max-w-[1440px] mx-2 px-10 h-full flex items-center justify-between">
         {/* [왼쪽] 로고 + 네비게이션 */}
         <div className="flex items-center gap-8">
           <Link to="/">
@@ -28,22 +36,30 @@ const Header = () => {
 
           <nav className="hidden md:flex gap-1">
             {menuItems.map((item) => (
-              <Button key={item} variant="ghost" className="font-medium">
-                {item}
-              </Button>
+              // 2. NavLink를 사용하여 경로 이동 및 활성화 상태 감지
+              <NavLink key={item.label} to={item.path}>
+                {({ isActive }) => (
+                  <Button
+                    variant="ghost"
+                    // 3. isActive가 true일 때 파란색(포인트 컬러) 적용, 아니면 기본색
+                    // cn() 함수가 중복된 text-color 클래스를 덮어씌워 줍니다.
+                    className={cn(
+                      "font-medium",
+                      isActive
+                        ? "text-headerTextActive font-bold"
+                        : "text-headerText"
+                    )}
+                  >
+                    {item.label}
+                  </Button>
+                )}
+              </NavLink>
             ))}
           </nav>
         </div>
 
         {/* [오른쪽] 유틸리티 버튼 + 로그인 */}
         <div className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            className="w-10 h-10 p-0 rounded-full hover:bg-headerIconHoverBg"
-          >
-            <MdLanguage className="absolute w-6 h-6 text-headerIcon" />
-          </Button>
-
           <ThemeToggle />
 
           <Button variant="primary" className="ml-3">

--- a/src/components/organisms/StockHeatmapWidget.tsx
+++ b/src/components/organisms/StockHeatmapWidget.tsx
@@ -1,0 +1,29 @@
+import { memo } from "react";
+import { TradingViewContainer } from "../molecules/TradingViewContainer";
+
+const StockHeatmapWidget = () => {
+  return (
+    <TradingViewContainer
+      scriptSrc="https://s3.tradingview.com/external-embedding/embed-widget-stock-heatmap.js"
+      getConfig={(theme) => ({
+        exchanges: [],
+        dataSource: "SPX500", // S&P 500 기준
+        grouping: "sector", // 섹터별 그룹화
+        blockSize: "market_cap_basic", // 시총 크기
+        blockColor: "change", // 등락률 색상
+        locale: "kr", // 한국어 설정
+        symbolUrl: "",
+        colorTheme: theme, // ✅ 다크/라이트 모드 자동 적용
+        hasTopBar: false,
+        isDataSetEnabled: false,
+        isZoomEnabled: true,
+        hasSymbolTooltip: true,
+        isMonoSize: false,
+        width: "100%",
+        height: "100%",
+      })}
+    />
+  );
+};
+
+export default memo(StockHeatmapWidget);

--- a/src/components/organisms/StockYTDHeatmapWidget.tsx
+++ b/src/components/organisms/StockYTDHeatmapWidget.tsx
@@ -1,0 +1,29 @@
+import { memo } from "react";
+import { TradingViewContainer } from "../molecules/TradingViewContainer";
+
+const StockHeatmapWidget = () => {
+  return (
+    <TradingViewContainer
+      scriptSrc="https://s3.tradingview.com/external-embedding/embed-widget-stock-heatmap.js"
+      getConfig={(theme) => ({
+        exchanges: [],
+        dataSource: "SPX500", // S&P 500 기준
+        grouping: "sector", // 섹터별 그룹화
+        blockSize: "market_cap_basic", // 시총 크기
+        blockColor: "Perf.YTD", // 등락률 색상
+        locale: "kr", // 한국어 설정
+        symbolUrl: "",
+        colorTheme: theme, // ✅ 다크/라이트 모드 자동 적용
+        hasTopBar: false,
+        isDataSetEnabled: false,
+        isZoomEnabled: true,
+        hasSymbolTooltip: true,
+        isMonoSize: false,
+        width: "100%",
+        height: "100%",
+      })}
+    />
+  );
+};
+
+export default memo(StockHeatmapWidget);

--- a/src/components/organisms/StockYTDHeatmapWidget.tsx
+++ b/src/components/organisms/StockYTDHeatmapWidget.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 import { TradingViewContainer } from "../molecules/TradingViewContainer";
 
-const StockHeatmapWidget = () => {
+const StockYTDHeatmapWidget = () => {
   return (
     <TradingViewContainer
       scriptSrc="https://s3.tradingview.com/external-embedding/embed-widget-stock-heatmap.js"
@@ -26,4 +26,4 @@ const StockHeatmapWidget = () => {
   );
 };
 
-export default memo(StockHeatmapWidget);
+export default memo(StockYTDHeatmapWidget);

--- a/src/components/templates/MainLayout.tsx
+++ b/src/components/templates/MainLayout.tsx
@@ -1,18 +1,22 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom"; // useLocation 추가
 import Header from "../organisms/Header";
 
 const MainLayout = () => {
+  const location = useLocation();
+  const fullWidthPages = ["/heatmap"];
+  const isFullWidth = fullWidthPages.includes(location.pathname);
+
   return (
-    <div className="min-h-screen w-full bg-background transition-colors duration-transitionDuration">
+    <div className="min-h-screen w-full bg-background transition-colors duration-transitionDuration mx-3">
       {/* 1. 헤더 영역 */}
       <Header />
 
       {/* 2. 메인 컨텐츠 영역 */}
-      {/* max-w-[1440px]: 최대 너비 제한 */}
-      {/* mx-auto: 화면 중앙 정렬 */}
-      {/* px-12: 좌우 패딩 48px (Tailwind에서 12 = 48px) */}
-      <main className="max-w-[1440px] mx-auto px-12 py-8">
-        {/* Outlet 자리에 HomePage가 들어옵니다 */}
+      <main
+        className={`max-w-[1440px] mx-auto ${
+          isFullWidth ? "px-0 py-0" : "px-12 py-8"
+        }`}
+      >
         <Outlet />
       </main>
     </div>

--- a/src/components/templates/MainLayout.tsx
+++ b/src/components/templates/MainLayout.tsx
@@ -7,7 +7,7 @@ const MainLayout = () => {
   const isFullWidth = fullWidthPages.includes(location.pathname);
 
   return (
-    <div className="min-h-screen w-full bg-background transition-colors duration-transitionDuration mx-3">
+    <div className="min-h-screen w-full bg-background transition-colors duration-transitionDuration">
       {/* 1. 헤더 영역 */}
       <Header />
 

--- a/src/components/templates/MainLayout.tsx
+++ b/src/components/templates/MainLayout.tsx
@@ -1,4 +1,5 @@
 import { Outlet, useLocation } from "react-router-dom"; // useLocation 추가
+import { cn } from "../../lib/utils";
 import Header from "../organisms/Header";
 
 const MainLayout = () => {
@@ -13,9 +14,10 @@ const MainLayout = () => {
 
       {/* 2. 메인 컨텐츠 영역 */}
       <main
-        className={`max-w-[1440px] mx-auto ${
+        className={cn(
+          "max-w-[1440px] mx-auto",
           isFullWidth ? "px-0 py-0" : "px-12 py-8"
-        }`}
+        )}
       >
         <Outlet />
       </main>

--- a/src/index.css
+++ b/src/index.css
@@ -55,7 +55,7 @@
   --header-search-placeholder: theme('colors.slate.400');
 
   --body-bg: theme('colors.slate.900');
-  --body-border: theme('colors.slate.800');
+  --body-border: theme('colors.slate.700');
 
   --body-text: theme('colors.slate.100');
   --body-text-muted: theme('colors.slate.500');

--- a/src/index.css
+++ b/src/index.css
@@ -6,37 +6,37 @@
 
 /* 라이트 모드 */
 :root {
-  --background: theme('colors.slate.50');
-  --border: theme('colors.slate.200');
+  --background: theme('colors.gray.50');
+  --border: theme('colors.gray.200');
 
-  --header-logo-text: theme('colors.slate.900');
-  --header-text: theme('colors.slate.400');
-  --header-text-hover: theme('colors.slate.700');
-  --header-text-active: theme('colors.slate.900');
+  --header-logo-text: theme('colors.gray.900');
+  --header-text: theme('colors.gray.400');
+  --header-text-hover: theme('colors.gray.700');
+  --header-text-active: theme('colors.gray.900');
 
-  --header-icon: theme('colors.slate.400');
-  --header-icon-hover-bg: theme('colors.slate.200');
+  --header-icon: theme('colors.gray.400');
+  --header-icon-hover-bg: theme('colors.gray.200');
 
-  --header-search-bg: theme('colors.slate.100');
-  --header-search-text: theme('colors.slate.700');
-  --header-search-placeholder: theme('colors.slate.400');
+  --header-search-bg: theme('colors.gray.100');
+  --header-search-text: theme('colors.gray.700');
+  --header-search-placeholder: theme('colors.gray.400');
 
   --body-bg: theme('colors.white');
-  --body-border: theme('colors.slate.200');
+  --body-border: theme('colors.gray.200');
 
-  --body-text: theme('colors.slate.900');
-  --body-text-muted: theme('colors.slate.500');
+  --body-text: theme('colors.gray.900');
+  --body-text-muted: theme('colors.gray.500');
   
-  --body-button-box-bg: theme('colors.slate.200');
-  --body-button-bg: theme('colors.slate.100');
-  --body-button-bg-hover: theme('colors.slate.100');
-  --body-button-text: theme('colors.slate.700');
-  --body-button-text-hover: theme('colors.slate.900');
-  --body-button-text-disabled: theme('colors.slate.400');
+  --body-button-box-bg: theme('colors.gray.200');
+  --body-button-bg: theme('colors.gray.100');
+  --body-button-bg-hover: theme('colors.gray.100');
+  --body-button-text: theme('colors.gray.700');
+  --body-button-text-hover: theme('colors.gray.900');
+  --body-button-text-disabled: theme('colors.gray.400');
 
-  --body-icon: theme('colors.slate.400');
+  --body-icon: theme('colors.gray.400');
 
-  --shadow-color: theme('colors.slate.200');
+  --shadow-color: theme('colors.gray.200');
 
   --glass-bg: rgba(230, 230, 230, 0.3);
   --glass-border: rgba(255, 255, 255, 0.2);
@@ -44,37 +44,37 @@
 
 /* 다크 모드 */
 [data-theme='dark'] {
-  --background: theme('colors.slate.950'); 
-  --border: theme('colors.slate.800');
+  --background: theme('colors.gray.950'); 
+  --border: theme('colors.gray.800');
 
-  --header-logo-text: theme('colors.slate.100');
-  --header-text: theme('colors.slate.400');
-  --header-text-hover: theme('colors.slate.100');
-  --header-text-active: theme('colors.slate.100');
+  --header-logo-text: theme('colors.gray.100');
+  --header-text: theme('colors.gray.400');
+  --header-text-hover: theme('colors.gray.100');
+  --header-text-active: theme('colors.gray.100');
 
-  --header-icon: theme('colors.slate.400');
-  --header-icon-hover-bg: theme('colors.slate.700');
+  --header-icon: theme('colors.gray.400');
+  --header-icon-hover-bg: theme('colors.gray.700');
 
-  --header-search-bg: theme('colors.slate.800');
-  --header-search-text: theme('colors.slate.300');
-  --header-search-placeholder: theme('colors.slate.400');
+  --header-search-bg: theme('colors.gray.800');
+  --header-search-text: theme('colors.gray.300');
+  --header-search-placeholder: theme('colors.gray.400');
 
-  --body-bg: theme('colors.slate.900');
-  --body-border: theme('colors.slate.700');
+  --body-bg: theme('colors.gray.900');
+  --body-border: theme('colors.gray.700');
 
-  --body-text: theme('colors.slate.100');
-  --body-text-muted: theme('colors.slate.500');
+  --body-text: theme('colors.gray.100');
+  --body-text-muted: theme('colors.gray.500');
   
-  --body-button-box-bg: theme('colors.slate.800');
-  --body-button-bg: theme('colors.slate.700');
-  --body-button-bg-hover: theme('colors.slate.700');
-  --body-button-text: theme('colors.slate.100');
-  --body-button-text-hover: theme('colors.slate.100');
-  --body-button-text-disabled: theme('colors.slate.400');
+  --body-button-box-bg: theme('colors.gray.800');
+  --body-button-bg: theme('colors.gray.700');
+  --body-button-bg-hover: theme('colors.gray.700');
+  --body-button-text: theme('colors.gray.100');
+  --body-button-text-hover: theme('colors.gray.100');
+  --body-button-text-disabled: theme('colors.gray.400');
 
-  --body-icon: theme('colors.slate.400');
+  --body-icon: theme('colors.gray.400');
 
-  --shadow-color: theme('colors.slate.800');
+  --shadow-color: theme('colors.gray.800');
 
   --glass-bg: rgba(20, 20, 20, 0.1);
   --glass-border: rgba(255, 255, 255, 0.2);
@@ -104,7 +104,7 @@
 
   ::-webkit-scrollbar-thumb:hover {
     /* 호버 시에만 색상을 적용합니다. */
-    background-color: theme('colors.slate.400');
+    background-color: theme('colors.gray.400');
   }
 }
 
@@ -116,13 +116,13 @@
   .skeleton::after {
     content: '';
     @apply absolute top-0 left-0 w-full h-full;
-    @apply bg-gradient-to-r from-transparent via-slate-300/50 to-transparent;
+    @apply bg-gradient-to-r from-transparent via-gray-300/50 to-transparent;
     @apply animate-shimmer;
     @apply transition-colors duration-transitionDuration;
   }
 
   /* 다크 모드일 때 빛나는 효과의 색상을 변경합니다. */
   [data-theme='dark'] .skeleton::after {
-    @apply via-slate-700/50;
+    @apply via-gray-700/50;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,11 @@
   --body-button-text-disabled: theme('colors.slate.400');
 
   --body-icon: theme('colors.slate.400');
+
+  --shadow-color: theme('colors.slate.200');
+
+  --glass-bg: rgba(230, 230, 230, 0.3);
+  --glass-border: rgba(255, 255, 255, 0.2);
 }
 
 /* 다크 모드 */
@@ -68,6 +73,11 @@
   --body-button-text-disabled: theme('colors.slate.400');
 
   --body-icon: theme('colors.slate.400');
+
+  --shadow-color: theme('colors.slate.800');
+
+  --glass-bg: rgba(20, 20, 20, 0.1);
+  --glass-border: rgba(255, 255, 255, 0.2);
 }
 
 /* 👇 [여기부터 추가!] 전역 스타일 설정 */

--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,7 @@
   --header-logo-text: theme('colors.slate.900');
   --header-text: theme('colors.slate.400');
   --header-text-hover: theme('colors.slate.700');
+  --header-text-active: theme('colors.slate.900');
 
   --header-icon: theme('colors.slate.400');
   --header-icon-hover-bg: theme('colors.slate.200');
@@ -44,6 +45,7 @@
   --header-logo-text: theme('colors.slate.100');
   --header-text: theme('colors.slate.400');
   --header-text-hover: theme('colors.slate.100');
+  --header-text-active: theme('colors.slate.100');
 
   --header-icon: theme('colors.slate.400');
   --header-icon-hover-bg: theme('colors.slate.700');

--- a/src/pages/HeatmapPage.tsx
+++ b/src/pages/HeatmapPage.tsx
@@ -1,0 +1,14 @@
+const HeatmapPage = () => {
+  return (
+    <div className="w-full min-h-[600px] flex flex-col items-center justify-center gap-4">
+      <h1 className="text-3xl font-bold text-slate-800 dark:text-white">
+        시장 히트맵 (준비중)
+      </h1>
+      <p className="text-slate-500">
+        여기에 주식/코인 히트맵이 들어갈 예정입니다.
+      </p>
+    </div>
+  );
+};
+
+export default HeatmapPage;

--- a/src/pages/HeatmapPage.tsx
+++ b/src/pages/HeatmapPage.tsx
@@ -1,23 +1,54 @@
+import ScrollIndicator from "../components/atoms/ScrollIndicator";
 import StockHeatmapWidget from "../components/organisms/StockHeatmapWidget";
+import StockYTDHeatmapWidget from "../components/organisms/StockYTDHeatmapWidget";
 
 const HeatmapPage = () => {
   return (
-    <div className="w-full flex flex-col gap-6">
-      {/* 1. 페이지 타이틀 (선택 사항) */}
-      <div>
-        <h1 className="text-2xl font-bold text-bodyText">
-          S&P 500 시장 히트맵
-        </h1>
-        <p className="text-sm text-bodyTextMuted mt-1">
-          시가총액 및 등락률 기반 실시간 시장 현황
-        </p>
-      </div>
+    // 1. [스크롤 컨테이너]
+    // h-[calc(100vh-64px)]: 헤더 높이(64px)를 뺀 나머지 화면을 꽉 채움
+    // overflow-y-auto: 세로 스크롤 허용
+    // snap-y snap-mandatory: 세로 방향 스냅 강제 적용
+    <div className="w-full h-[calc(100vh-64px)] overflow-y-auto snap-y snap-mandatory scroll-smooth">
+      {/* 2. [첫 번째 섹션] */}
+      {/* h-full: 컨테이너 높이(화면)를 꽉 채움 */}
+      {/* snap-start: 스크롤 시 이 섹션의 시작 부분에 자석처럼 붙음 */}
+      <section className="w-full h-full snap-start flex flex-col gap-6 px-12 py-8 box-border">
+        {/* 타이틀 영역 */}
+        <div className="flex-none">
+          <h1 className="text-2xl font-bold text-bodyText">
+            S&P 500 시장 히트맵
+          </h1>
+          <p className="text-sm text-bodyTextMuted mt-1">
+            시가총액 및 등락률 기반 실시간 시장 현황
+          </p>
+        </div>
 
-      {/* 2. 히트맵 위젯 영역 */}
-      {/* 높이를 화면 크기에 맞춰 꽉 차게 설정 (헤더 높이 고려 calc 사용 추천) */}
-      <div className="w-full h-[calc(100vh-200px)] min-h-[600px] rounded-xl overflow-hidden border border-border bg-background shadow-sm">
-        <StockHeatmapWidget />
-      </div>
+        {/* 위젯 영역 (남은 공간 채우기: flex-1) */}
+        <div className="flex-1 w-full min-h-0 rounded-xl overflow-hidden border border-border bg-background shadow-sm">
+          <StockHeatmapWidget />
+        </div>
+
+        <ScrollIndicator direction="up" />
+        <ScrollIndicator direction="down" />
+      </section>
+
+      {/* 3. [두 번째 섹션] */}
+      <section className="w-full h-full snap-start flex flex-col gap-6 px-12 py-8 box-border">
+        {/* 타이틀 영역 */}
+        <div className="flex-none">
+          <h1 className="text-2xl font-bold text-bodyText">
+            연초 대비 성과 (YTD)
+          </h1>
+          <p className="text-sm text-bodyTextMuted mt-1">
+            SPX500 주요 종목들의 연초부터 현재까지의 퍼포먼스
+          </p>
+        </div>
+
+        {/* 위젯 영역 (남은 공간 채우기: flex-1) */}
+        <div className="flex-1 w-full min-h-0 rounded-xl overflow-hidden border border-border bg-background shadow-sm">
+          <StockYTDHeatmapWidget />
+        </div>
+      </section>
     </div>
   );
 };

--- a/src/pages/HeatmapPage.tsx
+++ b/src/pages/HeatmapPage.tsx
@@ -1,12 +1,23 @@
+import StockHeatmapWidget from "../components/organisms/StockHeatmapWidget";
+
 const HeatmapPage = () => {
   return (
-    <div className="w-full min-h-[600px] flex flex-col items-center justify-center gap-4">
-      <h1 className="text-3xl font-bold text-slate-800 dark:text-white">
-        시장 히트맵 (준비중)
-      </h1>
-      <p className="text-slate-500">
-        여기에 주식/코인 히트맵이 들어갈 예정입니다.
-      </p>
+    <div className="w-full flex flex-col gap-6">
+      {/* 1. 페이지 타이틀 (선택 사항) */}
+      <div>
+        <h1 className="text-2xl font-bold text-bodyText">
+          S&P 500 시장 히트맵
+        </h1>
+        <p className="text-sm text-bodyTextMuted mt-1">
+          시가총액 및 등락률 기반 실시간 시장 현황
+        </p>
+      </div>
+
+      {/* 2. 히트맵 위젯 영역 */}
+      {/* 높이를 화면 크기에 맞춰 꽉 차게 설정 (헤더 높이 고려 calc 사용 추천) */}
+      <div className="w-full h-[calc(100vh-200px)] min-h-[600px] rounded-xl overflow-hidden border border-border bg-background shadow-sm">
+        <StockHeatmapWidget />
+      </div>
     </div>
   );
 };

--- a/src/pages/HeatmapPage.tsx
+++ b/src/pages/HeatmapPage.tsx
@@ -9,6 +9,9 @@ const HeatmapPage = () => {
     // overflow-y-auto: 세로 스크롤 허용
     // snap-y snap-mandatory: 세로 방향 스냅 강제 적용
     <div className="w-full h-[calc(100vh-64px)] overflow-y-auto snap-y snap-mandatory scroll-smooth">
+      <ScrollIndicator direction="up" />
+      <ScrollIndicator direction="down" />
+
       {/* 2. [첫 번째 섹션] */}
       {/* h-full: 컨테이너 높이(화면)를 꽉 채움 */}
       {/* snap-start: 스크롤 시 이 섹션의 시작 부분에 자석처럼 붙음 */}
@@ -27,9 +30,6 @@ const HeatmapPage = () => {
         <div className="flex-1 w-full min-h-0 rounded-xl overflow-hidden border border-border bg-background shadow-sm">
           <StockHeatmapWidget />
         </div>
-
-        <ScrollIndicator direction="up" />
-        <ScrollIndicator direction="down" />
       </section>
 
       {/* 3. [두 번째 섹션] */}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ export default {
         background: "var(--background)",
         headerLogoText: "var(--header-logo-text)",
         headerText: "var(--header-text)",
+        headerTextActive: "var(--header-text-active)",
         headerIcon: "var(--header-icon)",
         headerSearchBg: "var(--header-search-bg)",
         headerSearchText: "var(--header-search-text)",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,6 +29,11 @@ export default {
         bodyButtonTextHover: "var(--body-button-text-hover)",
         bodyButtonTextDisabled: "var(--body-button-text-disabled)",
         bodyIcon: "var(--body-icon)",
+        shadowColor: "var(--shadow-color)",
+        glass: {
+          DEFAULT: "var(--glass-bg)",
+          border: "var(--glass-border)",
+        },
       },
       keyframes: {
         shimmer: {


### PR DESCRIPTION
### 이슈 번호
Close #5 

### PR 요약
히트맵 페이지 구현

### 세부내용
히트맵 페이지에 트레이딩뷰 히트맵 위젯을 추가했습니다.

S&P 500 시장 히트맵, 연초 대비 성과 (YTD) 히트맵을 추가했습니다.

한 화면에 히트맵을 깔끔하게 보여주기 위해 스크롤 스냅을 적용했습니다.

히트맵이 한 화면에 하나만 보이기 때문에 사용자 입장에서 스크롤이 가능하다는 것을 알지 못할거 같다고 생각했습니다.
따라서 스크롤이 가능하다는 것을 알리기 위해 스크롤 인디케이터를 추가했습니다.

### 참고자료
